### PR TITLE
Added support for Vega 10 GPU featuremask

### DIFF
--- a/amdgpu-ls
+++ b/amdgpu-ls
@@ -85,7 +85,7 @@ def main():
     except FileNotFoundError:
         print("Cannot read ppfeaturemask. Exiting...")
         sys.exit(-1)
-    if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) :
+    if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) or featuremask == int(0xfffd7fff):
         print("AMD Wattman features enabled: %s" % hex(featuremask))
     else:
         print("AMD Wattman features not enabled: %s, See README file." % hex(featuremask))

--- a/amdgpu-monitor
+++ b/amdgpu-monitor
@@ -210,7 +210,7 @@ def main():
     except FileNotFoundError:
         print("Cannot read ppfeaturemask. Exiting...")
         sys.exit(-1)
-    if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) :
+    if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) or featuremask == int(0xfffd7fff) :
         print("AMD Wattman features enabled: %s" % hex(featuremask))
     else:
         print("AMD Wattman features not enabled: %s, See README file." % hex(featuremask))

--- a/amdgpu-pac
+++ b/amdgpu-pac
@@ -1419,7 +1419,7 @@ def main():
     except FileNotFoundError:
         print("Cannot read ppfeaturemask. Exiting...")
         sys.exit(-1)
-    if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) :
+    if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) or featuremask == int(0xfffd7fff):
         print("AMD Wattman features enabled: %s" % hex(featuremask))
     else:
         print("AMD Wattman features not enabled: %s, See README file." % hex(featuremask))

--- a/amdgpu-plot
+++ b/amdgpu-plot
@@ -721,7 +721,7 @@ def main():
         except FileNotFoundError:
             print("Cannot read ppfeaturemask. Exiting...")
             sys.exit(-1)
-        if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) :
+        if featuremask == int(0xffff7fff) or featuremask == int(0xffffffff) or featuremask == int(0xfffd7fff):
             print("AMD Wattman features enabled: %s" % hex(featuremask))
         else:
             print("AMD Wattman features not enabled: %s, See README file." % hex(featuremask))


### PR DESCRIPTION
Some Vega 10 GPU's require ppfeaturemask 0xfffd7fff to manipulate power settings. Adds support for mobile Vega 56 from Acer Predator Helios 500.